### PR TITLE
Support classes that define `attributes` and Range objects

### DIFF
--- a/.rubocop_defaults.yml
+++ b/.rubocop_defaults.yml
@@ -531,11 +531,11 @@ Metrics/BlockNesting:
 
 Metrics/ClassLength:
   CountComments: false  # count full line comments?
-  Max: 100
+  Max: 500
 
 Metrics/ModuleLength:
   CountComments: false  # count full line comments?
-  Max: 100
+  Max: 500
 
 # Avoid complex methods.
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.3 TBD
+
+ * call methods on any class that defines an `attributes` hash
+
 ## 0.1.2 `(13/01/2020)`
 
  * properly handle string and symbolic keys on hashes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.3 TBD
 
  * call methods on any class that defines an `attributes` hash
+ * support Range objects correctly
 
 ## 0.1.2 `(13/01/2020)`
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assert_generator (0.1.2)
+    assert_generator (0.1.3)
 
 GEM
   remote: https://rubygems.org/
@@ -67,4 +67,4 @@ DEPENDENCIES
   simplecov (~> 0.17, >= 0.17.1)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ which you can then paste into your code, and the asserts will pass.
 
 #### Arrays
 `t = [1,2,3]; AssertGenerator.generate_asserts(t, 't')`
+
 generates
+
 ```
 assert_equal 3, t.count
 assert_equal 1, t[0]
@@ -59,9 +61,18 @@ assert_equal 2, t[1]
 assert_equal 3, t[2]
 ```
 
+#### Ranges
+`t = (4..7); AssertGenerator.generate_asserts { 't' }`
+
+generates
+
+```
+assert_equal 4, t.first
+assert_equal 7, t.last
+```
+
 #### Hashes
 
-As above:
 ```
 h = { a: 2 }
 AssertGenerator.generate_asserts(h, 'h')
@@ -92,7 +103,7 @@ AssertGenerator.generate_asserts(relative_dates: 'Date.new(2019,11,1)') { 'd' }
 ```
 generates:
 ```
-assert_equal Date.new(2019,11,1) - 9/1.days, d
+assert_equal Date.new(2019,11,1) - 9.days, d
 ```
  
 ### Active Record
@@ -101,6 +112,8 @@ If you have an AR object `thing`, then `AssertGenerator.generate_asserts(thing, 
 will produce assertions for each attribute of the object.
 
 Note that index values and similar may well be wrong, unless you are using fixtures with a specified id. 
+
+Also, any class which quacks like AR by defining an `attributes` hash will be handled as for AR, allowing arbitrary classes to be tested.
 
 ## TODO
 

--- a/lib/assert_generator.rb
+++ b/lib/assert_generator.rb
@@ -58,8 +58,8 @@ module AssertGenerator
         return self
       end
 
-      if defined?(ActiveRecord::Base) && source.is_a?(ActiveRecord::Base)
-        generate_asserts_ar(source, source_expr)
+      if source.respond_to?(:attributes)
+        generate_asserts_attributes(source, source_expr)
         return self
       end
 
@@ -72,7 +72,8 @@ module AssertGenerator
       self
     end
 
-    def generate_asserts_ar(h, p)
+    # Active Record, or anything else with an attributes hash
+    def generate_asserts_attributes(h, p)
       h.attributes.each do |k, v|
         generate_assert_drillable_item(v, ->(meth) { "#{p}.#{meth}" }, k)
       end

--- a/lib/assert_generator/version.rb
+++ b/lib/assert_generator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AssertGenerator
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
This lets one drill into arbitrary classes by giving them an `attributes` hash.
Also, support a Range, and fix an issue with relative dates.