### PR TITLE
binding_of_caller is a runtime dependency for this gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     assert_generator (0.1.5)
+      binding_of_caller
 
 GEM
   remote: https://rubygems.org/
@@ -61,7 +62,6 @@ PLATFORMS
 
 DEPENDENCIES
   assert_generator!
-  binding_of_caller
   bundler (~> 2.0)
   minitest (~> 5.0)
   mocha (~> 1.9)

--- a/assert_generator.gemspec
+++ b/assert_generator.gemspec
@@ -25,13 +25,14 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/*.rb']
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'binding_of_caller'
+
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'mocha', '~> 1.9'
   spec.add_development_dependency 'rake', '>= 13.0'
   spec.add_development_dependency 'shoulda', '~> 3.6'
   # spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'binding_of_caller'
   spec.add_development_dependency 'rubocop', '~> 0.76'
   spec.add_development_dependency 'simplecov', '~> 0.17', '>= 0.17.1'
 end


### PR DESCRIPTION
The `binding_of_caller` gem is required in `lib/assert_generator.rb`, which is used during runtime, when the `AssertGenerator` itself is used as a gem. 

