### PR TITLE
Address image deprecation from 2020

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     docker:
-      - image: circleci/ruby:2.6.5
+      - image: cimg/ruby:2.6.5
 
     steps:
       - checkout


### PR DESCRIPTION
Vimaly [story](https://vimaly.com/#j8mqm/t/CircleCI_image_deprecation/g2FEASLzcsVyW154h)

Drop in replacement as described here:
https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/